### PR TITLE
fix: patch Snyk vulnerabilities in pip, setuptools, and black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.6.1 (2026-07-22)
+
+### Fix: Dependency security upgrades
+
+- Upgraded `black` to `>=26.3.1` to fix a high-severity Directory Traversal vulnerability ([SNYK-PYTHON-BLACK-15518063](https://security.snyk.io/vuln/SNYK-PYTHON-BLACK-15518063)).
+- Upgraded `pip` to `>=26.1.2` to fix Arbitrary File Upload ([SNYK-PYTHON-PIP-16115367](https://security.snyk.io/vuln/SNYK-PYTHON-PIP-16115367)), Arbitrary Code Injection ([SNYK-PYTHON-PIP-16316401](https://security.snyk.io/vuln/SNYK-PYTHON-PIP-16316401)), and Directory Traversal ([SNYK-PYTHON-PIP-16964647](https://security.snyk.io/vuln/SNYK-PYTHON-PIP-16964647)) vulnerabilities.
+- Upgraded `setuptools` to `>=83.0.0` to fix an Improper Unicode Encoding Handling vulnerability ([SNYK-PYTHON-SETUPTOOLS-17895075](https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-17895075)).
+
 ## v1.6.0 (2026-06-22)
 
 ### New feature: Multi-region endpoint resolution

--- a/contentstack_utils/__init__.py
+++ b/contentstack_utils/__init__.py
@@ -39,6 +39,6 @@ __all__ = (
 __title__ = 'contentstack_utils'
 __author__ = 'contentstack'
 __status__ = 'debug'
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 __endpoint__ = 'cdn.contentstack.io'
 __contact__ = 'support@contentstack.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pip~=26.0
-setuptools==80.3.1
+pip>=26.1.2
+setuptools>=83.0.0
 lxml~=6.1.0
 ruff==0.11.5
 pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-html>=4.2.0
-black>=24.3.0
+black>=26.3.1
 flake8>=6.0.0
 isort>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/contentstack/contentstack-utils-python",
     license='MIT',
-    version='1.6.0',
+    version='1.6.1',
     install_requires=[
 
     ],


### PR DESCRIPTION
## Summary
- Upgraded `pip` to `>=26.1.2` to fix Arbitrary File Upload, Arbitrary Code Injection, and Directory Traversal vulnerabilities
- Upgraded `setuptools` to `>=83.0.0` to fix Improper Unicode Encoding Handling vulnerability
- Upgraded `black` to `>=26.3.1` to fix a high-severity Directory Traversal vulnerability
- Bumped SDK version to `1.6.1` and updated `CHANGELOG.md`

## Test plan
- [x] `pip install -r requirements.txt --upgrade`
- [x] `pytest --html=tests/report/test-report.html` passes
- [x] `snyk test` no longer reports the black/pip/setuptools vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)